### PR TITLE
Implement withdraw-funds function for project withdrawal

### DIFF
--- a/contracts/fund_a_farm.clar
+++ b/contracts/fund_a_farm.clar
@@ -142,3 +142,48 @@
     )
   )
 )
+
+;; Read-only function to get a list of investors for a project
+(define-read-only (get-investors (project-id uint))
+  (match (map-get? project-investors {project-id: project-id})
+    investors-entry (ok (get investors investors-entry))
+    (err u404) ;; No investors found for the project
+  )
+)
+
+;; Return profits to investors after the project is completed
+(define-public (return-profits (project-id uint))
+  (let ((project (map-get? projects {project-id: project-id})))
+    (match project
+      project-data
+        (begin
+          ;; Ensure only the farmer can return profits
+          (asserts! (is-eq tx-sender (get farmer project-data)) (err u401))
+          ;; Ensure the project is closed
+          (asserts! (is-eq (get status project-data) "Closed") (err u402))
+
+          ;; Calculate ROI and distribute profits to investors
+          (let ((investors (unwrap! (get-investors project-id) (err u403))))
+            (map
+              (lambda (investor)
+                (match (map-get? investments {project-id: project-id, investor: investor})
+                  investment
+                    (let 
+                      (
+                        (amount (get amount investment))
+                        (profit (/ (* amount (get roi project-data)) u100))  ;; Calculate profit based on ROI
+                      )
+                      (try! (as-contract (stx-transfer? (+ amount profit) tx-sender investor)))  ;; Transfer profit and principal
+                    )
+                  (err u405) ;; Investment not found
+                )
+              )
+              investors
+            )
+          )
+          (ok true)
+        )
+      (err u400) ;; Project not found
+    )
+  )
+)

--- a/contracts/fund_a_farm.clar
+++ b/contracts/fund_a_farm.clar
@@ -108,3 +108,37 @@
     )
   )
 )
+
+;; Withdraw funds by the farmer after the project is fully funded
+(define-public (withdraw-funds (project-id uint))
+  (let ((project (unwrap! (map-get? projects {project-id: project-id}) (err "Project not found"))))
+    (match project
+      project-data
+        (begin
+          ;; Ensure only the farmer can withdraw the funds
+          (asserts! (is-eq tx-sender (get farmer project-data)) (err "Only the farmer can withdraw funds"))
+          ;; Ensure the project is fully funded or the funding period has ended
+          (asserts! (or (is-eq (get status project-data) 1) (>= block-height (get end-time project-data)))
+            (err "Funds cannot be withdrawn yet"))
+
+          ;; Transfer the raised amount to the farmer
+          (stx-transfer? (get amount-raised project-data) contract-owner tx-sender)
+
+          ;; Mark the project status as Closed
+          (map-set projects {project-id: project-id}
+            {
+              farmer: (get farmer project-data),
+              funding-goal: (get funding-goal project-data),
+              amount-raised: (get amount-raised project-data),
+              duration: (get duration project-data),
+              roi: (get roi project-data),
+              end-time: (get end-time project-data),
+              status: 2                               ;; Project status set to Closed
+            }
+          )
+          (ok "Funds withdrawn successfully")
+        )
+      (err "Project not found")
+    )
+  )
+)


### PR DESCRIPTION
### Add `withdraw-funds` functionality to Fund A Farm contract

This PR introduces the **`withdraw-funds`** functionality for the **Fund A Farm** contract, enabling farmers to withdraw funds after their project is fully funded or the funding period has ended. Key details of the implementation:

#### Function: `withdraw-funds`
- **Inputs**: 
  - `project-id`: The ID of the project from which the farmer wants to withdraw funds.
  
- **Core Logic**:
  - Ensures the project exists (`Project not found` error if it doesn't).
  - Validates that the caller (`tx-sender`) is the farmer who created the project (`Only the farmer can withdraw funds` error if not).
  - Checks if the project is either fully funded (`status = 1`) or if the funding period has ended (`block-height >= end-time`). If neither condition is met, the contract throws an error (`Funds cannot be withdrawn yet`).
  
- **Fund Transfer**:
  - Transfers the total amount raised to the farmer’s account.

- **Project Closure**:
  - Updates the project status to `Closed` (`status = 2`).
  - Stores the updated project data back into the `projects` map.

#### Example Success Flow:
1. Farmer creates a project.
2. Project receives investments and is fully funded or the funding period ends.
3. Farmer calls the `withdraw-funds` function to transfer the raised funds to their account.
4. The project is marked as `Closed`, preventing further investments.

This ensures proper fund management and project lifecycle in the contract.
